### PR TITLE
fix(docs): add links to source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,78 +4,78 @@
 
 All reasonably stable tools
 
-**AccessMask** - decode access mask for common object types
+**[AccessMask](https://github.com/zodiacon/AccessMask)** - decode access mask for common object types
 
-**BgInfo** - WPF version of the Sysinternals BgInfo tool
+**[BgInfo](https://github.com/zodiacon/BgInfo)** - WPF version of the Sysinternals BgInfo tool
 
-**BITSMgr** - BITS jobs manager application
+**[BITSMgr](https://github.com/zodiacon/BITSManager)** - BITS jobs manager application
 
-**CLR Explorer** - View .NET process information / dump file
+**[CLR Explorer](https://github.com/zodiacon/CLRExplorer)** - View .NET process information / dump file
 
-**CpuStres** - thread/CPU stress testing app
+**[CpuStres](https://github.com/zodiacon/CPUStress)** - thread/CPU stress testing app
 
-**CpuStress v3** - thread/CPU stress testing app
+**[CpuStress v3](https://github.com/zodiacon/CPUStress)** - thread/CPU stress testing app
 
 **DebugPrint** - monitor OutputDebugString/DbgPrint(Ex) calls (no driver needed)
 
-**DriverMon** - monitor any driver activity
+**[DriverMon](https://github.com/zodiacon/DriverMon)** - monitor any driver activity
 
-**ErrorLookup** - error code description for Win32 (GetLastError) and NTSTATUS
+**[ErrorLookup](https://github.com/zodiacon/ErrorLookup)** - error code description for Win32 (GetLastError) and NTSTATUS
 
-**ETWExplorer** - view ETW XML manifests for registered providers
+**[ETWExplorer](https://github.com/zodiacon/EtwExplorer)** - view ETW XML manifests for registered providers
 
 **FSClass** - lists the file system filter classes (command line)
 
-**GFlagsX** - enhanced version of the GFlags tool
+**[GFlagsX](https://github.com/zodiacon/GflagsX)** - enhanced version of the GFlags tool
 
-**INF Studio** - view/edit INF files
+**[INF Studio](https://github.com/zodiacon/InfStudio)** - view/edit INF files
 
 **Kdump64** - generate a local kernel dump (64 bit)
 
-**KernelObjectView** - View stats of kernel objects and handles in the system
+**[KernelObjectView](https://github.com/zodiacon/KernelObjectView)** - View stats of kernel objects and handles in the system
 
-**MetroManager** - list (and launch) installed Windows Runtime components and apps
+**[MetroManager](https://github.com/zodiacon/MetroManager)** - list (and launch) installed Windows Runtime components and apps
 
 **MemMapView** - view any process memory (including protected and minimal processes)
 
-**NtfsStreams** - show NTFS alternate streams in files
+**[NtfsStreams](https://github.com/zodiacon/NtfsStreams)** - show NTFS alternate streams in files
 
-**ObjDir** - command line tool to show object manager namespace
+**[ObjDir](https://github.com/zodiacon/ObjDir)** - command line tool to show object manager namespace
 
-**ObjExp** - Object Explorer, explore objects and handles
+**[ObjExp](https://github.com/zodiacon/ObjectExplorer)** - Object Explorer, explore objects and handles
 
-**PEExplorer** - PE file viewer
+**[PEExplorer](https://github.com/zodiacon/PEExplorer)** - PE file viewer
 
-**PEExplorerV2** - PE file viewer version 2.0
+**[PEExplorerV2](https://github.com/zodiacon/PEExplorerV2)** - PE file viewer version 2.0
 
-**PoolMonXv2** - kernel pool memory (version 2)
+**[PoolMonXv2](https://github.com/zodiacon/PoolMonXv2)** - kernel pool memory (version 2)
 
-**PdbView** - view PDB files
+**[PdbView](https://github.com/zodiacon/PdbView)** - view PDB files
 
-**PerfMonX** - enhanced Performance Monitor tool
+**[PerfMonX](https://github.com/zodiacon/PerfMonX)** - enhanced Performance Monitor tool
 
-**ProcMonX** - ProcMon-like tool based on Event Tracing for Windows (ETW)
+**[ProcMonX](https://github.com/zodiacon/ProcMonX)** - ProcMon-like tool based on Event Tracing for Windows (ETW)
 
-**ProcMonX v2** - Enhanced ProcMon-like tool based on Event Tracing for Windows (ETW)
+**[ProcMonX v2](https://github.com/zodiacon/ProcMonXv2)** - Enhanced ProcMon-like tool based on Event Tracing for Windows (ETW)
 
 **QSlice** - modern version of the classic QSlice tool
 
 **QSliceX** - pie chart graphics for QSlice
 
-**Sysrun** - run any executable with the SYSTEM account (no service needed)
+**[Sysrun](https://github.com/zodiacon/sysrun)** - run any executable with the SYSTEM account (no service needed)
 
-**System Explorer** - system, processes, threads, objects, handles, and other information - all in one tool
+**[System Explorer](https://github.com/zodiacon/SystemExplorer)** - system, processes, threads, objects, handles, and other information - all in one tool
 
-**Total PE** - Yet another PE viewer (WIP)
+**[Total PE](https://github.com/zodiacon/TotalPE)** - Yet another PE viewer (WIP)
 
-**TotalReg** - Total Registry - view/edit real Registry, undo/redo, and much more.
+**[TotalReg](https://github.com/zodiacon/TotalRegistry)** - Total Registry - view/edit real Registry, undo/redo, and much more.
 
-**WindowTitleEx** - Show HWND, TID, PID on windows. Revert with included tray icon
+**[WindowTitleEx](https://github.com/zodiacon/WindowTitleEx)** - Show HWND, TID, PID on windows. Revert with included tray icon
 
-**WinSpy** - show windows and monitor messages. A WIP alternative to Spy++.
+**[WinSpy](https://github.com/zodiacon/WinSpy)** - show windows and monitor messages. A WIP alternative to Spy++.
 
-**winsta** - Show current session's window stations, desktops and top level visible windows (with non-empty titles)
+**[winsta](https://github.com/zodiacon/winsta)** - Show current session's window stations, desktops and top level visible windows (with non-empty titles)
 
-**XCalculator** (XCalc) - simple calculator supporting variables and functions
+**[XCalculator](https://github.com/zodiacon/CalculatorX)** (XCalc) - simple calculator supporting variables and functions
 
 


### PR DESCRIPTION
This PR adds links to source code for each of the tool.

There are a few tools I couldn't get their repos/sources or some that I couldn't differentiate:
- DebugPrint
- FSClass
- Kdump64
- MemMapView
- QSlice
- QSliceX